### PR TITLE
Fix build for Faust OTT plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+ott_dsp.cpp
+ott_dsp.o
+ott.o
+

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ SDK      ?= $(CURDIR)/distingnt_api/
 FAUST    ?= faust
 
 PLUGIN   := ott
-SRCS     := ott_dsp.cpp ott_wrapper.cpp
+SRCS     := ott_dsp.cpp
 OBJS     := $(SRCS:.cpp=.o)
 
 # Build rules ------------------------------------------------------------------
 all: $(PLUGIN).o
 
 ott_dsp.cpp: ott.dsp
-	$(FAUST) -a $(SDK)/faust/nt_arch.cpp $< -o $@
+	$(FAUST) -a $(SDK)/faust/nt_arch.cpp -uim -nvi -mem $< -o $@
 
 %.o: %.cpp
 	$(CXX) -std=c++17 -I$(SDK)/include \


### PR DESCRIPTION
## Summary
- adjust Makefile to invoke the distingNT Faust architecture with UI macros
- compile only the generated DSP source
- ignore generated build artifacts

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684db618ff848332af5a65a8f7e3c6fd