### PR TITLE
Improve OTT UI interactions and debugging

### DIFF
--- a/ott_algo.cpp
+++ b/ott_algo.cpp
@@ -81,6 +81,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
 
     default: break;   // routing params have no Faust target
     }
+    a->lastParam = p;
+    a->lastValue = v;
 }
 
 /*──────────────────────────  Audio step  ───────────────────────────*/

--- a/ott_structs.h
+++ b/ott_structs.h
@@ -11,4 +11,9 @@ struct _ottAlgorithm : public _NT_algorithm
     FaustDsp* dsp = nullptr;
     ParamUI   ui;
     UIState   state;
+    int       lastParam = -1;
+    int16_t   lastValue = 0;
+    float     potCatch[3] = {0.f,0.f,0.f};
+    bool      potCaught[3] = {false,false,false};
+    int       potTarget[3] = {-1,-1,-1};
 };

--- a/ott_ui.cpp
+++ b/ott_ui.cpp
@@ -1,11 +1,18 @@
 #include "ott_structs.h"
 #include "ott_ui.h"
 #include "ott_parameters.h"   // enums & params[] (see next section)
+#include <string>
 
 /* sync soft-takeover when the algorithm page appears */
 void setupUi(_NT_algorithm* self, _NT_float3& pots)
 {
     pots[0] = 0.5f; pots[1] = 0.5f; pots[2] = 0.5f;   // centre the knobs
+    auto* a = (_ottAlgorithm*)self;
+    for (int i=0;i<3;++i) {
+        a->potCaught[i] = false;
+        a->potTarget[i] = -1;
+        a->potCatch[i] = pots[i];
+    }
 }
 
 bool draw(_NT_algorithm* self)
@@ -25,6 +32,18 @@ bool draw(_NT_algorithm* self)
     const char* encMode = ui.encMode == UIState::XOVER ? "XOVER" : "GLOBAL";
     NT_drawText(2, 30, encMode);
 
+    if (a->lastParam >= 0) {
+        char buf[40];
+        NT_drawText(70, 20, params[a->lastParam].name);
+        if (params[a->lastParam].scaling == kNT_scaling10)
+            NT_floatToString(buf, a->lastValue * 0.1f, 1);
+        else if (params[a->lastParam].unit == kNT_unitPercent)
+            NT_floatToString(buf, a->lastValue * 0.01f, 2);
+        else
+            NT_intToString(buf, a->lastValue);
+        NT_drawText(180, 20, buf);
+    }
+
     // Lets draw the values of the pots according to our state
     int16_t hiDownThr = a->ui.get("High/DownThr");
 
@@ -32,6 +51,41 @@ bool draw(_NT_algorithm* self)
     int x2 = mapHzToX(a->ui.get("Xover/MidHighFreq"));
     NT_drawShapeI(kNT_line, x1, 10, x1, 50, 8);
     NT_drawShapeI(kNT_line, x2, 10, x2, 50, 8);
+
+    auto drawBand = [&](int xStart, int xEnd, const char* name){
+        char key[32];
+        snprintf(key, sizeof(key), "%s/DownThr", name);
+        float dThr = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/UpThr", name);
+        float uThr = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/DownRat", name);
+        float dRat = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/UpRat", name);
+        float uRat = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/Makeup", name);
+        float gain = a->ui.get(key);
+        int yDown = mapDbToY(dThr);
+        int yUp   = mapDbToY(uThr);
+        NT_drawShapeI(kNT_line, xStart, yDown, xEnd, yDown, 10);
+        NT_drawShapeI(kNT_line, xStart, yUp,   xEnd, yUp,   10);
+        int dTilt = int(5 * dRat);
+        int uTilt = int(5 * uRat);
+        NT_drawShapeI(kNT_line, xStart, yDown, xEnd, yDown-dTilt, 12);
+        NT_drawShapeI(kNT_line, xStart, yUp,   xEnd, yUp+uTilt,   12);
+        int xBar = (xStart+xEnd)/2;
+        int yGain = mapGainToY(gain);
+        NT_drawShapeI(kNT_line, xBar, 50, xBar, yGain, 15);
+    };
+
+    drawBand(0, x1, "Low");
+    drawBand(x1, x2, "Mid");
+    drawBand(x2, 240, "High");
+
+    int xGW = 250;
+    int yWet = mapPercentToY(a->ui.get("Global/Wet"));
+    int yGain = mapGainToY(a->ui.get("Global/OutGain"));
+    NT_drawShapeI(kNT_line, xGW, 50, xGW, yWet, 14);
+    NT_drawShapeI(kNT_line, xGW+5, 50, xGW+5, yGain, 14);
 
     return false;   // keep standard parameter strip
 }
@@ -60,14 +114,14 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
 
     /* pots → three bands */
     const int potTargets[3][3] = {
-        { kHiDownThr, kHiDownRat, kHiMakeup },
+        { kLoDownThr, kLoDownRat, kLoMakeup },
         { kMidDownThr,kMidDownRat,kMidMakeup },
-        { kLoDownThr, kLoDownRat, kLoMakeup }
+        { kHiDownThr, kHiDownRat, kHiMakeup }
     };
     const int potTargetsUp[3][3] = {
-        { kHiUpThr, kHiUpRat, -1 },
+        { kLoUpThr, kLoUpRat, -1 },
         { kMidUpThr,kMidUpRat,-1 },
-        { kLoUpThr, kLoUpRat, -1 }
+        { kHiUpThr, kHiUpRat, -1 }
     };
 
     for (int p = 0; p < 3; ++p) {
@@ -76,8 +130,20 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
             (ui.potMode == UIState::THRESH) ? (pressed? potTargetsUp[p][0] : potTargets[p][0]) :
             (ui.potMode == UIState::RATIO ) ? (pressed? potTargetsUp[p][1] : potTargets[p][1]) :
                                               potTargets[p][2];
-        if (tgt >= 0)
-            pushParam(self, tgt, scalePot(tgt, data.pots[p]));
+        if (tgt >= 0) {
+            if (a->potTarget[p] != tgt) {
+                a->potTarget[p] = tgt;
+                a->potCaught[p] = false;
+                a->potCatch[p] = (self->v[tgt] - params[tgt].min) / float(params[tgt].max - params[tgt].min);
+            }
+            float pos = data.pots[p];
+            if (!a->potCaught[p]) {
+                if (fabsf(pos - a->potCatch[p]) < 0.05f)
+                    a->potCaught[p] = true;
+            }
+            if (a->potCaught[p])
+                pushParam(self, tgt, scalePot(tgt, pos));
+        }
     }
 
     /* encoders */
@@ -89,8 +155,12 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
         (ui.encMode == UIState::XOVER) ? kXoverMidHi : kGlobalWet
     };
     const float encStep[2] = {
-        (ui.encMode == UIState::XOVER) ? (encPressL ? 100.f : 10.f) : (encPressL ? 1.f : 0.1f),
-        (ui.encMode == UIState::XOVER) ? (encPressR ? 100.f : 10.f) : (encPressR ? 1.f : 0.1f),
+        (ui.encMode == UIState::XOVER)
+            ? (encPressL ? (self->v[kXoverLoMid] * 0.1f) : 10.f)
+            : (encPressL ? 1.f : 0.1f),
+        (ui.encMode == UIState::XOVER)
+            ? (encPressR ? (self->v[kXoverMidHi] * 0.1f) : 10.f)
+            : (encPressR ? 1.f : 0.1f),
     };
 
     for (int e=0; e<2; ++e) {
@@ -106,6 +176,21 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
 int mapHzToX(float hz)
 {
     return int((log10f(hz) - 1.f) * 240.f / 3.f);
+}
+
+int mapDbToY(float db)
+{
+    return 50 - int(((db + 60.f) / 100.f) * 40.f);
+}
+
+int mapGainToY(float db)
+{
+    return 50 - int(((db + 24.f) / 48.f) * 40.f);
+}
+
+int mapPercentToY(float p)
+{
+    return 50 - int((p / 100.f) * 40.f);
 }
 
 int16_t scalePot(int idx, float pot)

--- a/ott_ui.h
+++ b/ott_ui.h
@@ -60,6 +60,9 @@ void     setupUi   (_NT_algorithm*, _NT_float3&);
 bool     draw      (_NT_algorithm*);
 
 int   mapHzToX(float hz);
+int   mapDbToY(float db);
+int   mapGainToY(float db);
+int   mapPercentToY(float p);
 int16_t scalePot(int idx, float pot);
 
 static inline int fast_lrintf(float x)


### PR DESCRIPTION
## Summary
- track last parameter modification and show value in debug text
- add soft-takeover logic for pots
- flip pots to control low/mid/high order
- visualize thresholds, ratios, band gain, and global settings on screen
- make encoder fast mode scale with current crossover frequency

## Testing
- `make clean && make`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684ed1b53c9c8332a3e1a28b7e7123d9