### PR TITLE
Update README to reflect refactored codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project builds a disting-NT plug-in that uses a DSP generated from the
 [Faust](https://github.com/grame-cncm/faust) compiler.
 
 The Faust source (`ott.dsp`) is translated to C++ during the build and linked
-with a custom C++ UI in `ott_wrapper.cpp`.
+with custom C++ code split across `ott_algo.cpp`, `ott_ui.cpp` and `newlib_stub.cpp`.
 
 ## Cloning
 
@@ -32,3 +32,7 @@ make clean && make
 
 This will generate `ott_dsp.cpp` from `ott.dsp` and build `ott.o`, which can be
 loaded on a disting-NT device.
+
+## Environment and limitations
+
+This plug-in targets the [disting NT](https://www.expert-sleepers.co.uk/) hardware (ARM Cortex-M7). The Makefile builds `ott.o` using partial linking (`-r`) and disables exceptions and RTTI. The firmware does not provide the standard C or C++ libraries. Instead `newlib_stub.cpp` implements a tiny bump allocator and minimal runtime support. Only lightweight headers like `<cstdint>` are used; containers and other STL facilities are unavailable. See `distingnt_api/include/distingnt/api.h` for the full API.


### PR DESCRIPTION
## Summary
- note that the code is now split across several C++ files
- describe how the plugin is compiled for the Disting NT
- explain the limited runtime and the absence of the C++ standard library

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_684ed327876883329295f80ee7032b7c