### PR TITLE
Fix OTT ratio/threshold UI

### DIFF
--- a/ott_ui.h
+++ b/ott_ui.h
@@ -60,7 +60,8 @@ void     setupUi   (_NT_algorithm*, _NT_float3&);
 bool     draw      (_NT_algorithm*);
 
 int   mapHzToX(float hz);
-int   mapDbToY(float db);
+int   mapDownThrToY(float db);
+int   mapUpThrToY(float db);
 int   mapGainToY(float db);
 int   mapPercentToY(float p);
 int16_t scalePot(int idx, float pot);


### PR DESCRIPTION
## Summary
- fix rendering of down/up threshold boxes
- overlay UI text after drawing graphics

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684eea3c071083328c3eb211ca585499