### PR TITLE
Improve controls and visuals

### DIFF
--- a/ott.dsp
+++ b/ott.dsp
@@ -1,7 +1,7 @@
 import("stdfaust.lib");
 
 //===== CROSSOVER FREQS ======================================
-c1 = hslider("Xover/LowMidFreq[unit:Hz]", 160, 20, 1000, 1);
+c1 = hslider("Xover/LowMidFreq[unit:Hz]", 160, 40, 1000, 1);
 c2 = hslider("Xover/MidHighFreq[unit:Hz]", 2500, 300, 16000, 1);
 
 //===== LOW BAND =============================================

--- a/ott_algo.cpp
+++ b/ott_algo.cpp
@@ -77,7 +77,7 @@ static void parameterChanged(_NT_algorithm* s, int p)
         a->ui.set("Xover/MidHighFreq", v);
         break;
     case kGlobalOut:   a->ui.set("Global/OutGain",   0.1f * v); break;
-    case kGlobalWet:   a->ui.set("Global/Wet",       0.01f * v); break;
+    case kGlobalWet:   a->ui.set("Global/Wet",       v); break;
 
     default: break;   // routing params have no Faust target
     }

--- a/ott_parameters.h
+++ b/ott_parameters.h
@@ -77,7 +77,7 @@ static const _NT_parameter params[kNumParams] = {
     P("Low/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
 
     /*  X-over & global  */
-    P("Xover/LoMid",  100, 18000, 400,  kNT_unitHz,      0),
+    P("Xover/LoMid",   40, 18000, 400,  kNT_unitHz,      0),
     P("Xover/MidHi",  100, 20000,2500,  kNT_unitHz,      0),
     P("Global/Out",  -240,  240,    0,  kNT_unitDb,      kNT_scaling10),
     P("Global/Wet",     0,  100,  100,  kNT_unitPercent, 0),

--- a/ott_structs.h
+++ b/ott_structs.h
@@ -16,4 +16,5 @@ struct _ottAlgorithm : public _NT_algorithm
     float     potCatch[3] = {0.f,0.f,0.f};
     bool      potCaught[3] = {false,false,false};
     int       potTarget[3] = {-1,-1,-1};
+    bool      potUpper[3] = {false,false,false};
 };


### PR DESCRIPTION
## Summary
- adjust crossover frequency minimum to 40 Hz
- fix global wet parameter mapping and bar drawing
- introduce band gap and extend high band to 20 kHz
- toggle pot upper/lower targets with a click
- switch encoder speed logic and tweak wet encoder

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684ef3da882c8332b79260e57d248dfe