### PR TITLE
Add per-band attack/release controls

### DIFF
--- a/ott.dsp
+++ b/ott.dsp
@@ -4,6 +4,14 @@ import("stdfaust.lib");
 c1 = hslider("Xover/LowMidFreq[unit:Hz]", 160, 40, 1000, 1);
 c2 = hslider("Xover/MidHighFreq[unit:Hz]", 2500, 300, 16000, 1);
 
+//===== ATTACK / RELEASE (ms converted to seconds) ============================
+L_att = hslider("Low/Attack[unit:ms]", 47.8, 0.1, 500, 0.1) / 1000.0;
+L_rel = hslider("Low/Release[unit:ms]", 282, 1, 2000, 0.1) / 1000.0;
+M_att = hslider("Mid/Attack[unit:ms]", 22.4, 0.1, 500, 0.1) / 1000.0;
+M_rel = hslider("Mid/Release[unit:ms]", 282, 1, 2000, 0.1) / 1000.0;
+H_att = hslider("High/Attack[unit:ms]", 13.5, 0.1, 500, 0.1) / 1000.0;
+H_rel = hslider("High/Release[unit:ms]", 132, 1, 2000, 0.1) / 1000.0;
+
 //===== LOW BAND =============================================
 L_thd  = hslider("Low/DownThr[dB]", -35, -60, 0, 0.1);
 L_thu  = hslider("Low/UpThr[dB]"  , -20, -60, 0, 0.1);
@@ -30,8 +38,9 @@ wet  = hslider("Global/Wet[unit:%]", 100, 0, 100, 0.1) / 100.0;
 outg = hslider("Global/OutGain[dB]",   0, -24, 24, 0.1);
 
 //===== HELPERS ==============================================
-db2lin(x)   = pow(10, x/20);
-env_foll(x) = abs(x) : si.smooth(0.05);
+db2lin(x) = pow(10, x/20);
+// envelope follower with attack and release times
+env_foll(at, rt, x) = abs(x) : an.amp_follower_ar(at, rt);
 
 // bidirectional gain (old-syntax safe)
 ud_gain(env, td, tu, rd, ru) = g with {
@@ -46,8 +55,8 @@ ud_gain(env, td, tu, rd, ru) = g with {
 };  // <- semicolon required for Faust 2.37
 
 // per-band processor
-band(sig, td, tu, rd, ru, mk) = sig * gain with {
-  env  = env_foll(sig);
+band(sig, td, tu, rd, ru, mk, at, rt) = sig * gain with {
+  env  = env_foll(at, rt, sig);
   gain = ud_gain(env, td, tu, rd, ru) * db2lin(mk);
 };
 
@@ -61,9 +70,9 @@ chain(x) = y with {
   hi_i = x : hp;
   mid_i= x - lo_i - hi_i;
 
-  lo_p  = band(lo_i , L_thd,L_thu,L_ratd,L_ratu,L_make);
-  mid_p = band(mid_i, M_thd,M_thu,M_ratd,M_ratu,M_make);
-  hi_p  = band(hi_i , H_thd,H_thu,H_ratd,H_ratu,H_make);
+  lo_p  = band(lo_i , L_thd,L_thu,L_ratd,L_ratu,L_make, L_att,L_rel);
+  mid_p = band(mid_i, M_thd,M_thu,M_ratd,M_ratu,M_make, M_att,M_rel);
+  hi_p  = band(hi_i , H_thd,H_thu,H_ratd,H_ratu,H_make, H_att,H_rel);
 
   wetmix = lo_p + mid_p + hi_p;
   y = (wetmix * wet + x * (1 - wet)) * db2lin(outg);

--- a/ott_algo.cpp
+++ b/ott_algo.cpp
@@ -46,6 +46,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
     case kHiDownRat:   a->ui.set("High/DownRat",   0.01f * v); break;
     case kHiUpRat:     a->ui.set("High/UpRat",     0.01f * v); break;
     case kHiMakeup:    a->ui.set("High/Makeup",    0.1f * v); break;
+    case kHiAttack:    a->ui.set("High/Attack",    0.1f * v); break;
+    case kHiRelease:   a->ui.set("High/Release",   0.1f * v); break;
 
     /* Mid band */
     case kMidDownThr:  a->ui.set("Mid/DownThr",    0.1f * v); break;
@@ -53,6 +55,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
     case kMidDownRat:  a->ui.set("Mid/DownRat",    0.01f * v); break;
     case kMidUpRat:    a->ui.set("Mid/UpRat",      0.01f * v); break;
     case kMidMakeup:   a->ui.set("Mid/Makeup",     0.1f * v); break;
+    case kMidAttack:   a->ui.set("Mid/Attack",     0.1f * v); break;
+    case kMidRelease:  a->ui.set("Mid/Release",    0.1f * v); break;
 
     /* Low band */
     case kLoDownThr:   a->ui.set("Low/DownThr",    0.1f * v); break;
@@ -60,6 +64,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
     case kLoDownRat:   a->ui.set("Low/DownRat",    0.01f * v); break;
     case kLoUpRat:     a->ui.set("Low/UpRat",      0.01f * v); break;
     case kLoMakeup:    a->ui.set("Low/Makeup",     0.1f * v); break;
+    case kLoAttack:    a->ui.set("Low/Attack",     0.1f * v); break;
+    case kLoRelease:   a->ui.set("Low/Release",    0.1f * v); break;
 
     /* X-over & global */
     case kXoverLoMid:

--- a/ott_parameters.h
+++ b/ott_parameters.h
@@ -9,16 +9,19 @@ enum {
     kHiDownThr, kHiUpThr,
     kHiDownRat, kHiUpRat,
     kHiMakeup,
+    kHiAttack, kHiRelease,
 
     /* Mid band */
     kMidDownThr, kMidUpThr,
     kMidDownRat, kMidUpRat,
     kMidMakeup,
+    kMidAttack, kMidRelease,
 
     /* Lo band */
     kLoDownThr, kLoUpThr,
     kLoDownRat, kLoUpRat,
     kLoMakeup,
+    kLoAttack, kLoRelease,
 
     /* X-over  + global */
     kXoverLoMid, kXoverMidHi,
@@ -28,9 +31,9 @@ enum {
 };
 
 
-static const uint8_t pageHi[]     = { kHiDownThr,kHiUpThr,kHiDownRat,kHiUpRat,kHiMakeup };
-static const uint8_t pageMid[]    = { kMidDownThr,kMidUpThr,kMidDownRat,kMidUpRat,kMidMakeup };
-static const uint8_t pageLow[]    = { kLoDownThr,kLoUpThr,kLoDownRat,kLoUpRat,kLoMakeup };
+static const uint8_t pageHi[]     = { kHiDownThr,kHiUpThr,kHiDownRat,kHiUpRat,kHiMakeup,kHiAttack,kHiRelease };
+static const uint8_t pageMid[]    = { kMidDownThr,kMidUpThr,kMidDownRat,kMidUpRat,kMidMakeup,kMidAttack,kMidRelease };
+static const uint8_t pageLow[]    = { kLoDownThr,kLoUpThr,kLoDownRat,kLoUpRat,kLoMakeup,kLoAttack,kLoRelease };
 static const uint8_t pageGlobal[] = { kXoverLoMid,kXoverMidHi,kGlobalOut,kGlobalWet };
 static const uint8_t pageRouting[] = { kInL,kInR,kOutL,kOutLMode,kOutR,kOutRMode };
 
@@ -55,12 +58,14 @@ static const _NT_parameter params[kNumParams] = {
     NT_PARAMETER_AUDIO_OUTPUT_WITH_MODE("Out L", 1, 13)
     NT_PARAMETER_AUDIO_OUTPUT_WITH_MODE("Out R", 2, 14)
 
-    /*  High band  (dB, %, dB) */
+    /*  High band  (dB, %, dB, ms) */
     P("Hi/DownThr", -600,   0, -120, kNT_unitDb,       kNT_scaling10),
     P("Hi/UpThr",      0,  400, 120, kNT_unitDb,       kNT_scaling10),
     P("Hi/DownRat",   10, 1000, 500, kNT_unitPercent,  kNT_scaling10),
     P("Hi/UpRat",     10, 8000,2000, kNT_unitPercent,  kNT_scaling10),
     P("Hi/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Hi/Attack",     1,  5000, 135, kNT_unitMs,      kNT_scaling10),
+    P("Hi/Release",   10, 20000,1320, kNT_unitMs,      kNT_scaling10),
 
     /*  Mid band  */
     P("Mid/DownThr", -600,   0, -120, kNT_unitDb,       kNT_scaling10),
@@ -68,6 +73,8 @@ static const _NT_parameter params[kNumParams] = {
     P("Mid/DownRat",   10, 1000, 500, kNT_unitPercent,  kNT_scaling10),
     P("Mid/UpRat",     10, 8000,2000, kNT_unitPercent,  kNT_scaling10),
     P("Mid/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Mid/Attack",     1,  5000, 224, kNT_unitMs,      kNT_scaling10),
+    P("Mid/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),
 
     /*  Low band  */
     P("Low/DownThr", -600,   0, -120, kNT_unitDb,       kNT_scaling10),
@@ -75,6 +82,8 @@ static const _NT_parameter params[kNumParams] = {
     P("Low/DownRat",   10, 1000, 500, kNT_unitPercent,  kNT_scaling10),
     P("Low/UpRat",     10, 8000,2000, kNT_unitPercent,  kNT_scaling10),
     P("Low/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Low/Attack",     1,  5000, 478, kNT_unitMs,      kNT_scaling10),
+    P("Low/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),
 
     /*  X-over & global  */
     P("Xover/LoMid",   40, 18000, 400,  kNT_unitHz,      0),


### PR DESCRIPTION
## Summary
- expose attack/release sliders in `ott.dsp`
- use `an.amp_follower_ar` for envelope following
- route new parameters in C++ side
- list attack/release params for disting-NT

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684f3bc8111083328cff2445a799ed7c