### PR TITLE
Fix compression threshold ordering and UI scaling

### DIFF
--- a/ott_algo.cpp
+++ b/ott_algo.cpp
@@ -42,14 +42,14 @@ static void parameterChanged(_NT_algorithm* s, int p)
     {
     /* Hi band */
     case kHiDownThr:
-        if (v > s->v[kHiUpThr]) {
+        if (v < s->v[kHiUpThr]) {
             pushParam(s, kHiDownThr, s->v[kHiUpThr]);
             return;
         }
         a->ui.set("High/DownThr",   0.1f * v);
         break;
     case kHiUpThr:
-        if (v < s->v[kHiDownThr]) {
+        if (v > s->v[kHiDownThr]) {
             pushParam(s, kHiUpThr, s->v[kHiDownThr]);
             return;
         }
@@ -63,14 +63,14 @@ static void parameterChanged(_NT_algorithm* s, int p)
 
     /* Mid band */
     case kMidDownThr:
-        if (v > s->v[kMidUpThr]) {
+        if (v < s->v[kMidUpThr]) {
             pushParam(s, kMidDownThr, s->v[kMidUpThr]);
             return;
         }
         a->ui.set("Mid/DownThr",    0.1f * v);
         break;
     case kMidUpThr:
-        if (v < s->v[kMidDownThr]) {
+        if (v > s->v[kMidDownThr]) {
             pushParam(s, kMidUpThr, s->v[kMidDownThr]);
             return;
         }
@@ -84,14 +84,14 @@ static void parameterChanged(_NT_algorithm* s, int p)
 
     /* Low band */
     case kLoDownThr:
-        if (v > s->v[kLoUpThr]) {
+        if (v < s->v[kLoUpThr]) {
             pushParam(s, kLoDownThr, s->v[kLoUpThr]);
             return;
         }
         a->ui.set("Low/DownThr",    0.1f * v);
         break;
     case kLoUpThr:
-        if (v < s->v[kLoDownThr]) {
+        if (v > s->v[kLoDownThr]) {
             pushParam(s, kLoUpThr, s->v[kLoDownThr]);
             return;
         }

--- a/ott_ui.cpp
+++ b/ott_ui.cpp
@@ -227,16 +227,16 @@ int mapHzToX(float hz)
 
 int mapDownThrToY(float db)
 {
-    // map -60..0 dB to screen Y 30..10
+    // map -60..0 dB across the full vertical range 60..10
     float norm = (db + 60.f) / 60.f;        // 0..1
-    return 30 - int(norm * 20.f);
+    return 60 - int(norm * 50.f);
 }
 
 int mapUpThrToY(float db)
 {
-    // map -60..0 dB to screen Y 60..30
+    // map -60..0 dB across the full vertical range 60..10
     float norm = (db + 60.f) / 60.f;        // 0..1
-    return 60 - int(norm * 30.f);
+    return 60 - int(norm * 50.f);
 }
 
 int mapGainToY(float db)


### PR DESCRIPTION
## Summary
- correct parameter validation so downward thresholds cannot fall below upward thresholds
- allow upward thresholds only below or equal to downward thresholds
- map threshold display to the full Y range

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_684f461084488332b9660643522fc4ee