### PR TITLE
Expand ratio range to 1–100

### DIFF
--- a/ott.dsp
+++ b/ott.dsp
@@ -15,22 +15,22 @@ H_rel = hslider("High/Release[unit:ms]", 132, 1, 2000, 0.1) / 1000.0;
 //===== LOW BAND =============================================
 L_thd  = hslider("Low/DownThr[dB]", -10, -60, 0, 0.1);
 L_thu  = hslider("Low/UpThr[dB]"  , -30, -60, 0, 0.1);
-L_ratd = hslider("Low/DownRat"    ,   4,   1, 20, 0.01);
-L_ratu = hslider("Low/UpRat"      ,   2,   1, 20, 0.01);
+L_ratd = hslider("Low/DownRat"    ,   4,   1, 100, 0.01);
+L_ratu = hslider("Low/UpRat"      ,   2,   1, 100, 0.01);
 L_make = hslider("Low/Makeup[dB]" ,   0, -24, 24, 0.1);
 
 //===== MID BAND =============================================
 M_thd  = hslider("Mid/DownThr[dB]", -10, -60, 0, 0.1);
 M_thu  = hslider("Mid/UpThr[dB]"  , -30, -60, 0, 0.1);
-M_ratd = hslider("Mid/DownRat"    ,   4,   1, 20, 0.01);
-M_ratu = hslider("Mid/UpRat"      ,   2,   1, 20, 0.01);
+M_ratd = hslider("Mid/DownRat"    ,   4,   1, 100, 0.01);
+M_ratu = hslider("Mid/UpRat"      ,   2,   1, 100, 0.01);
 M_make = hslider("Mid/Makeup[dB]" ,   0, -24, 24, 0.1);
 
 //===== HIGH BAND ============================================
 H_thd  = hslider("High/DownThr[dB]", -10, -60, 0, 0.1);
 H_thu  = hslider("High/UpThr[dB]"  , -30, -60, 0, 0.1);
-H_ratd = hslider("High/DownRat"    ,   4,   1, 20, 0.01);
-H_ratu = hslider("High/UpRat"      ,   2,   1, 20, 0.01);
+H_ratd = hslider("High/DownRat"    ,   4,   1, 100, 0.01);
+H_ratu = hslider("High/UpRat"      ,   2,   1, 100, 0.01);
 H_make = hslider("High/Makeup[dB]" ,   0, -24, 24, 0.1);
 
 //===== GLOBAL MIX / OUTPUT =================================

--- a/ott_parameters.h
+++ b/ott_parameters.h
@@ -61,8 +61,8 @@ static const _NT_parameter params[kNumParams] = {
     /*  High band  (dB, %, dB) */
     P("Hi/DownThr", -600,   0, -100, kNT_unitDb,       kNT_scaling10),
     P("Hi/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
-    P("Hi/DownRat", 100, 2000, 400, kNT_unitPercent,  kNT_scaling10),
-    P("Hi/UpRat",   100, 2000, 200, kNT_unitPercent,  kNT_scaling10),
+    P("Hi/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
+    P("Hi/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
     P("Hi/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Hi/Attack",     1,  5000, 135, kNT_unitMs,      kNT_scaling10),
     P("Hi/Release",   10, 20000,1320, kNT_unitMs,      kNT_scaling10),
@@ -70,8 +70,8 @@ static const _NT_parameter params[kNumParams] = {
     /*  Mid band  */
     P("Mid/DownThr", -600,   0, -100, kNT_unitDb,       kNT_scaling10),
     P("Mid/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
-    P("Mid/DownRat", 100, 2000, 400, kNT_unitPercent,  kNT_scaling10),
-    P("Mid/UpRat",   100, 2000, 200, kNT_unitPercent,  kNT_scaling10),
+    P("Mid/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
+    P("Mid/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
     P("Mid/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Mid/Attack",     1,  5000, 224, kNT_unitMs,      kNT_scaling10),
     P("Mid/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),
@@ -79,8 +79,8 @@ static const _NT_parameter params[kNumParams] = {
     /*  Low band  */
     P("Low/DownThr", -600,   0, -100, kNT_unitDb,       kNT_scaling10),
     P("Low/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
-    P("Low/DownRat", 100, 2000, 400, kNT_unitPercent,  kNT_scaling10),
-    P("Low/UpRat",   100, 2000, 200, kNT_unitPercent,  kNT_scaling10),
+    P("Low/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
+    P("Low/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
     P("Low/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Low/Attack",     1,  5000, 478, kNT_unitMs,      kNT_scaling10),
     P("Low/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),

--- a/ott_ui.cpp
+++ b/ott_ui.cpp
@@ -36,12 +36,16 @@ bool draw(_NT_algorithm* self)
     char lastVal[40] = {0};
     if (a->lastParam >= 0) {
         lastName = params[a->lastParam].name;
-        if (params[a->lastParam].scaling == kNT_scaling10)
+        if (params[a->lastParam].unit == kNT_unitPercent) {
+            if (params[a->lastParam].scaling == kNT_scaling10)
+                NT_floatToString(lastVal, a->lastValue * 0.01f, 1);
+            else
+                NT_floatToString(lastVal, a->lastValue * 0.01f, 2);
+        } else if (params[a->lastParam].scaling == kNT_scaling10) {
             NT_floatToString(lastVal, a->lastValue * 0.1f, 1);
-        else if (params[a->lastParam].unit == kNT_unitPercent)
-            NT_floatToString(lastVal, a->lastValue * 0.01f, 2);
-        else
+        } else {
             NT_intToString(lastVal, a->lastValue);
+        }
     }
 
     // Draw the values of the pots according to our state


### PR DESCRIPTION
## Summary
- widen compressor ratios for each band
- fix on-screen ratio display so it shows correct value

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6866c9eb3374833293800526e1c48bf1