### PR TITLE
Add pre/post gain per band

### DIFF
--- a/ott_algo.cpp
+++ b/ott_algo.cpp
@@ -64,7 +64,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
         break;
     case kHiDownRat:   a->ui.set("High/DownRat",   0.01f * v); break;
     case kHiUpRat:     a->ui.set("High/UpRat",     0.01f * v); break;
-    case kHiMakeup:    a->ui.set("High/Makeup",    0.1f * v); break;
+    case kHiPreGain:   a->ui.set("High/PreGain",   0.1f * v); break;
+    case kHiPostGain:  a->ui.set("High/PostGain",  0.1f * v); break;
     case kHiAttack:    a->ui.set("High/Attack",    0.1f * v); break;
     case kHiRelease:   a->ui.set("High/Release",   0.1f * v); break;
 
@@ -85,7 +86,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
         break;
     case kMidDownRat:  a->ui.set("Mid/DownRat",    0.01f * v); break;
     case kMidUpRat:    a->ui.set("Mid/UpRat",      0.01f * v); break;
-    case kMidMakeup:   a->ui.set("Mid/Makeup",     0.1f * v); break;
+    case kMidPreGain:  a->ui.set("Mid/PreGain",    0.1f * v); break;
+    case kMidPostGain: a->ui.set("Mid/PostGain",   0.1f * v); break;
     case kMidAttack:   a->ui.set("Mid/Attack",     0.1f * v); break;
     case kMidRelease:  a->ui.set("Mid/Release",    0.1f * v); break;
 
@@ -106,7 +108,8 @@ static void parameterChanged(_NT_algorithm* s, int p)
         break;
     case kLoDownRat:   a->ui.set("Low/DownRat",    0.01f * v); break;
     case kLoUpRat:     a->ui.set("Low/UpRat",      0.01f * v); break;
-    case kLoMakeup:    a->ui.set("Low/Makeup",     0.1f * v); break;
+    case kLoPreGain:   a->ui.set("Low/PreGain",    0.1f * v); break;
+    case kLoPostGain:  a->ui.set("Low/PostGain",   0.1f * v); break;
     case kLoAttack:    a->ui.set("Low/Attack",     0.1f * v); break;
     case kLoRelease:   a->ui.set("Low/Release",    0.1f * v); break;
 

--- a/ott_parameters.h
+++ b/ott_parameters.h
@@ -8,19 +8,19 @@ enum {
     /* Hi band */
     kHiDownThr, kHiUpThr,
     kHiDownRat, kHiUpRat,
-    kHiMakeup,
+    kHiPreGain, kHiPostGain,
     kHiAttack, kHiRelease,
 
     /* Mid band */
     kMidDownThr, kMidUpThr,
     kMidDownRat, kMidUpRat,
-    kMidMakeup,
+    kMidPreGain, kMidPostGain,
     kMidAttack, kMidRelease,
 
     /* Lo band */
     kLoDownThr, kLoUpThr,
     kLoDownRat, kLoUpRat,
-    kLoMakeup,
+    kLoPreGain, kLoPostGain,
     kLoAttack, kLoRelease,
 
     /* X-over  + global */
@@ -31,9 +31,9 @@ enum {
 };
 
 
-static const uint8_t pageHi[]     = { kHiDownThr,kHiUpThr,kHiDownRat,kHiUpRat,kHiMakeup,kHiAttack,kHiRelease };
-static const uint8_t pageMid[]    = { kMidDownThr,kMidUpThr,kMidDownRat,kMidUpRat,kMidMakeup,kMidAttack,kMidRelease };
-static const uint8_t pageLow[]    = { kLoDownThr,kLoUpThr,kLoDownRat,kLoUpRat,kLoMakeup,kLoAttack,kLoRelease };
+static const uint8_t pageHi[]     = { kHiDownThr,kHiUpThr,kHiDownRat,kHiUpRat,kHiPreGain,kHiPostGain,kHiAttack,kHiRelease };
+static const uint8_t pageMid[]    = { kMidDownThr,kMidUpThr,kMidDownRat,kMidUpRat,kMidPreGain,kMidPostGain,kMidAttack,kMidRelease };
+static const uint8_t pageLow[]    = { kLoDownThr,kLoUpThr,kLoDownRat,kLoUpRat,kLoPreGain,kLoPostGain,kLoAttack,kLoRelease };
 static const uint8_t pageGlobal[] = { kXoverLoMid,kXoverMidHi,kGlobalOut,kGlobalWet };
 static const uint8_t pageRouting[] = { kInL,kInR,kOutL,kOutLMode,kOutR,kOutRMode };
 
@@ -63,7 +63,8 @@ static const _NT_parameter params[kNumParams] = {
     P("Hi/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
     P("Hi/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
     P("Hi/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
-    P("Hi/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Hi/PreGain", -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Hi/PostGain",-240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Hi/Attack",     1,  5000, 135, kNT_unitMs,      kNT_scaling10),
     P("Hi/Release",   10, 20000,1320, kNT_unitMs,      kNT_scaling10),
 
@@ -72,7 +73,8 @@ static const _NT_parameter params[kNumParams] = {
     P("Mid/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
     P("Mid/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
     P("Mid/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
-    P("Mid/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Mid/PreGain", -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Mid/PostGain",-240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Mid/Attack",     1,  5000, 224, kNT_unitMs,      kNT_scaling10),
     P("Mid/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),
 
@@ -81,7 +83,8 @@ static const _NT_parameter params[kNumParams] = {
     P("Low/UpThr",  -600,   0, -300, kNT_unitDb,       kNT_scaling10),
     P("Low/DownRat", 100, 10000, 400, kNT_unitPercent,  kNT_scaling10),
     P("Low/UpRat",   100, 10000, 200, kNT_unitPercent,  kNT_scaling10),
-    P("Low/Makeup",  -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Low/PreGain", -240,  240,   0, kNT_unitDb,       kNT_scaling10),
+    P("Low/PostGain",-240,  240,   0, kNT_unitDb,       kNT_scaling10),
     P("Low/Attack",     1,  5000, 478, kNT_unitMs,      kNT_scaling10),
     P("Low/Release",   10, 20000,2820, kNT_unitMs,      kNT_scaling10),
 

--- a/ott_ui.cpp
+++ b/ott_ui.cpp
@@ -65,8 +65,10 @@ bool draw(_NT_algorithm* self)
         float dRat = a->ui.get(key);
         snprintf(key, sizeof(key), "%s/UpRat", name);
         float uRat = a->ui.get(key);
-        snprintf(key, sizeof(key), "%s/Makeup", name);
-        float gain = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/PreGain", name);
+        float pre = a->ui.get(key);
+        snprintf(key, sizeof(key), "%s/PostGain", name);
+        float post = a->ui.get(key);
 
         int yDown = mapDownThrToY(dThr);
         int yUp   = mapUpThrToY(uThr);
@@ -102,8 +104,17 @@ bool draw(_NT_algorithm* self)
         }
 
         int xBar = (xStart + xEnd) / 2;
-        int yGain = mapGainToY(gain);
-        NT_drawShapeI(kNT_line, xBar, 60, xBar, yGain, 15);
+        int xPre  = xBar - 1;
+        int xPost = xBar + 1;
+        int yPre  = mapGainToY(pre);
+        int yPost = mapGainToY(post);
+        NT_drawShapeI(kNT_line, xPre, 60, xPre, yPre, 15);
+        NT_drawShapeI(kNT_line, xPost,60, xPost,yPost,15);
+        if (ui.potMode == UIState::GAIN) {
+            bool upperSel = a->potUpper[idx];
+            int xText = upperSel ? xPre : xPost;
+            NT_drawText(xText, 62, upperSel?"pre":"post", 15, kNT_textCentre, kNT_textTiny);
+        }
     };
 
     int xGW = 246;
@@ -161,14 +172,14 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
 
     /* pots → three bands */
     const int potTargets[3][3] = {
-        { kLoDownThr, kLoDownRat, kLoMakeup },
-        { kMidDownThr,kMidDownRat,kMidMakeup },
-        { kHiDownThr, kHiDownRat, kHiMakeup }
+        { kLoDownThr, kLoDownRat, kLoPostGain },
+        { kMidDownThr,kMidDownRat,kMidPostGain },
+        { kHiDownThr, kHiDownRat, kHiPostGain }
     };
     const int potTargetsUp[3][3] = {
-        { kLoUpThr, kLoUpRat, -1 },
-        { kMidUpThr,kMidUpRat,-1 },
-        { kHiUpThr, kHiUpRat, -1 }
+        { kLoUpThr, kLoUpRat, kLoPreGain },
+        { kMidUpThr,kMidUpRat,kMidPreGain },
+        { kHiUpThr, kHiUpRat, kHiPreGain }
     };
 
     for (int p = 0; p < 3; ++p) {
@@ -179,7 +190,7 @@ void customUi(_NT_algorithm* self, const _NT_uiData& data)
         int  tgt =
             (ui.potMode == UIState::THRESH) ? (upper? potTargetsUp[p][0] : potTargets[p][0]) :
             (ui.potMode == UIState::RATIO ) ? (upper? potTargetsUp[p][1] : potTargets[p][1]) :
-                                             potTargets[p][2];
+                                             (upper? potTargetsUp[p][2] : potTargets[p][2]);
         if (tgt >= 0) {
             if (a->potTarget[p] != tgt) {
                 a->potTarget[p] = tgt;


### PR DESCRIPTION
## Summary
- add PreGain/PostGain sliders for each band in `ott.dsp`
- support new gain parameters in `ott_parameters.h`
- handle new parameters in UI controls and display
- update DSP parameter routing in `ott_algo.cpp`

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6866d1165c9c8332acadd1a277eca5aa